### PR TITLE
fix(routing): also write when empty query

### DIFF
--- a/src/modules/createInstantSearchRouting.js
+++ b/src/modules/createInstantSearchRouting.js
@@ -22,7 +22,7 @@ export default ({ context, indexName }) => ({
             });
 
             if (typeof history === 'object') {
-                history.pushState(routeState, null, query);
+                history.pushState(routeState, null, query || location.pathname);
             }
         },
         createURL(routeState) {


### PR DESCRIPTION
if there's no items in the query string, qs will return an empty string. This means that you are then calling `history.pushState(routeState, null, '')`, which is considered as "don't navigate" (correctly). A workaround is either to use pathname as a fallback (as I've done here), or alternatively writing `location.pathname + query`

fixes https://github.com/algolia/vue-instantsearch/issues/832